### PR TITLE
Remove gray background from Skills section

### DIFF
--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -7,7 +7,7 @@ export default function Skills() {
   const categories = Array.from(new Set(skills.map((s) => s.category)));
 
   return (
-    <section id="skills" className="container py-20 bg-gray-50">
+    <section id="skills" className="container py-20">
       <h2 className="text-4xl font-bold mb-12 text-center">Skills</h2>
 
       <div className="space-y-16">


### PR DESCRIPTION
Eliminated the 'bg-gray-50' class from the Skills section to display the default background. This change may improve visual consistency with other sections.